### PR TITLE
Add horizontal pod autoscaler for ambassador pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ module "ambassador" {
 | ambassador_image | Ambassador_image	Image | string | `quay.io/datawire/ambassador` | no |
 | ambassador_image_tag | Ambassador_image image tag | string | `0.40.2` | no |
 | ambassador_namespace_name | Set the AMBASSADOR_NAMESPACE environment variable | string | `metadata.namespace` | no |
+| autoscaling_min_replicas | Sets minimum replica count for the horizontal pod autoscaler | string | `3` | no |
+| autoscaling_max_replicas | Sets maximum replica count for the horizontal pod autoscaler | string | `6` | no |
+| autoscaling_target_cpu_utilization_percentage | Sets the target CPU utilization percentage for the horizontal pod autoscaler | string | `50` | no |
 | cluster_role_name | Set cluster rolne name, defaults to name | string | `` | no |
 | daemon_set | If true Create a daemonSet. By default Deployment controller will be created | string | `false` | no |
 | exporter_configuration | Prometheus exporter configuration in YALM format | string | `` | no |
@@ -73,7 +76,6 @@ module "ambassador" {
 | namespace_create | Create the namespace, must set a unique namespace_name | string | `false` | no |
 | namespace_name | Kubernetes namespace name | string | `default` | no |
 | rbac_create | If true, create and use RBAC resources | string | `true` | no |
-| replica_count | Number of Ambassador replicas | string | `1` | no |
 | resources_limits_cpu | CPU limit | string | `1` | no |
 | resources_limits_memory | memory limit | string | `1Gi` | no |
 | resources_requests_cpu | CPU requests | string | `200m` | no |

--- a/deployment.tf
+++ b/deployment.tf
@@ -2,14 +2,16 @@
 resource "kubernetes_deployment" "this" {
   count = false == var.daemon_set ? 1 : 0
 
+  lifecycle {
+    ignore_changes = [spec.0.replicas]
+  }
+
   metadata {
     name      = var.name
     namespace = var.namespace_name
   }
 
   spec {
-    replicas = var.replica_count
-
     selector {
       match_labels = {
         app = var.name

--- a/horizontal_pod_autoscaler.tf
+++ b/horizontal_pod_autoscaler.tf
@@ -1,0 +1,23 @@
+# Create a horizontal pod autoscaler for the service when autoscaling is enabled
+resource "kubernetes_horizontal_pod_autoscaler" "ambassador" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace_name
+  }
+
+  spec {
+    min_replicas = var.autoscaling_min_replicas
+    max_replicas = var.autoscaling_max_replicas
+
+    target_cpu_utilization_percentage = var.autoscaling_target_cpu_utilization_percentage
+
+    scale_target_ref {
+      kind = "Deployment"
+      name = var.name
+    }
+  }
+
+  depends_on = [
+    kubernetes_deployment.this,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,11 +44,6 @@ variable "daemon_set" {
   description = "If true Create a daemonSet. By default Deployment controller will be created"
 }
 
-variable "replica_count" {
-  default     = 1
-  description = "Number of Ambassador replicas"
-}
-
 variable "volumes" {
   description = "Volumes for the ambassador service"
   default     = []
@@ -209,5 +204,20 @@ variable "lables_global" {
   description = "Additional global lables to be applied, list of maps"
   default     = []
   type        = list(string)
+}
+
+variable "autoscaling_min_replicas" {
+  description = "This field sets minimum autoscaling replica count"
+  default     = 3
+}
+
+variable "autoscaling_max_replicas" {
+  description = "This field sets maximum autoscaling replica count"
+  default     = 6
+}
+
+variable "autoscaling_target_cpu_utilization_percentage" {
+  description = "Configure the target cpu utilization percentage for each container"
+  default     = 50
 }
 


### PR DESCRIPTION
The autoscaler is optional and not created by default. Currently only
configurable metric is target CPU utilization, but could add more
options using the "metric" parameter in future.