### PR TITLE
Make scale_target_ref api_version match deployment

### DIFF
--- a/horizontal_pod_autoscaler.tf
+++ b/horizontal_pod_autoscaler.tf
@@ -12,8 +12,9 @@ resource "kubernetes_horizontal_pod_autoscaler" "ambassador" {
     target_cpu_utilization_percentage = var.autoscaling_target_cpu_utilization_percentage
 
     scale_target_ref {
-      kind = "Deployment"
-      name = var.name
+      api_version = "extensions/v1beta1"
+      kind        = "Deployment"
+      name        = var.name
     }
   }
 


### PR DESCRIPTION
In an attempt to fix the following error when creating the horizontal
pod autoscaler:

the HPA controller was unable to get the target's current scale: no
matches for kind "Deployment" in group ""

From what I can tell, this is caused when the referent (in this case the
deployment) version is different to what the autoscaler expects.

https://www.terraform.io/docs/providers/kubernetes/r/horizontal_pod_autoscaler.html#arguments-10

Results of `kubectl describe hpa -n system-ambassador-external ambassador-external`:

```
Name:                                                  ambassador-external
Namespace:                                             system-ambassador-external
Labels:                                                <none>
Annotations:                                           <none>
CreationTimestamp:                                     Thu, 11 Jun 2020 12:57:00 +1200
Reference:                                             Deployment/ambassador-external
Metrics:                                               ( current / target )
  resource cpu on pods  (as a percentage of request):  <unknown> / 50%
Min replicas:                                          3
Max replicas:                                          6
Deployment pods:                                       0 current / 0 desired
Conditions:
  Type         Status  Reason          Message
  ----         ------  ------          -------
  AbleToScale  False   FailedGetScale  the HPA controller was unable to get the target's current scale: no matches for kind "Deployment" in group ""
Events:
  Type     Reason          Age                  From                       Message
  ----     ------          ----                 ----                       -------
  Warning  FailedGetScale  4s (x10 over 2m20s)  horizontal-pod-autoscaler  no matches for kind "Deployment" in group ""
```