### PR TITLE
Set resource requests/limits for statsd sidecar

### DIFF
--- a/daemonset.tf
+++ b/daemonset.tf
@@ -56,6 +56,18 @@ resource "kubernetes_daemonset" "this" {
             "-statsd.mapping-config=/statsd-exporter/mapping-config.yaml",
           ]
 
+          resources {
+            requests {
+              memory = var.resources_statsd_requests_memory
+              cpu    = var.resources_statsd_requests_cpu
+            }
+
+            limits {
+              memory = var.resources_statsd_limits_memory
+              cpu    = var.resources_statsd_limits_cpu
+            }
+          }
+
           port {
             container_port = 9102
             name           = "metrics"

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,26 @@ variable "resources_limits_memory" {
   default     = "1Gi"
 }
 
+variable "resources_statsd_requests_cpu" {
+  description = "CPU requests for statsd sidecar container"
+  default     = "50m"
+}
+
+variable "resources_statsd_requests_memory" {
+  description = "memory requests for statsd sidecar container"
+  default     = "100Mi"
+}
+
+variable "resources_statsd_limits_cpu" {
+  description = "CPU limit for statsd sidecar container"
+  default     = "50m"
+}
+
+variable "resources_statsd_limits_memory" {
+  description = "memory limit for statsd sidecar container"
+  default     = "100Mi"
+}
+
 variable "rbac_create" {
   default     = true
   description = "If true, create and use RBAC resources"


### PR DESCRIPTION
Need this for the autoscaler to work correctly. Generally pods should
always include resource requests/limits for Kubernetes to be able to
schedule workloads efficiently.

also seeing as we don't have CI for this repo yet: 

![Screen Shot 2020-06-16 at 12 12 50 PM](https://user-images.githubusercontent.com/48230581/84717706-b9949b00-afca-11ea-923a-f45514094a02.png)

![Screen Shot 2020-06-16 at 12 12 41 PM](https://user-images.githubusercontent.com/48230581/84717703-b8636e00-afca-11ea-913d-529e69b49768.png)
