### PR TITLE
Fix statsd metrics exposition on the Ambassador deployment

### DIFF
--- a/deployment.tf
+++ b/deployment.tf
@@ -111,10 +111,27 @@ resource "kubernetes_deployment" "this" {
             name  = "AMBASSADOR_ID"
             value = var.ambassador_id
           }
+
           env {
             name  = "AMBASSADOR_DEBUG"
             value = var.ambassador_debug
           }
+
+          env {
+            name  = "STATSD_ENABLED"
+            value = true
+          }
+
+          env {
+            name  = "STATSD_HOST"
+            value = "localhost"
+          }
+
+          env {
+            name  = "STATSD_PORT"
+            value = 8125
+          }
+
           env {
             name = "AMBASSADOR_NAMESPACE"
 


### PR DESCRIPTION
Previously, the ambassador pod had a statsd sink and was exposing prometheus metrics, but due to a misconfiguration, ambassador wasn't sending its statsd metrics to the sink, meaning they weren't being exposed to prometheus.

This commit adds the necessary configuration to make Ambassador push statsd metrics to the sink. It adds the following envars:
```Env
STATSD_ENABLED=true
STATSD_HOST=localhost
STATSD_PORT=8125
```

**Of note:** The the ambassador docs ([monitoring](https://www.getambassador.io/docs/pre-release/topics/running/statistics/) and [environment](https://www.getambassador.io/docs/pre-release/topics/running/environment/)) actually disagree on what the correct envar is to enable statsd exposition - I tried both `STATSD_ENABLED` and `USE_STATSD`, and found that only `STATSD_ENABLED` worked correctly.

Also, we technically don't need the `STATSD_PORT` envar, as it's set to the default value, but I put it there for completeness' sake.