### PR TITLE
Native prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ module "ambassador" {
 | cluster_role_name | Set cluster rolne name, defaults to name | string | `` | no |
 | daemon_set | If true Create a daemonSet. By default Deployment controller will be created | string | `false` | no |
 | exporter_configuration | Prometheus exporter configuration in YALM format | string | `` | no |
-| exporter_image | Prometheus exporter image | string | `prom/statsd-exporter` | no |
 | exporter_image_tag | Prometheus exporter image tag | string | `v0.6.0` | no |
 | image_pull_policy | Image pull policy | string | `IfNotPresent` | no |
 | image_pull_secrets | Image pull secrets | list | `<list>` | no |

--- a/daemonset.tf
+++ b/daemonset.tf
@@ -18,12 +18,13 @@ resource "kubernetes_daemonset" "this" {
       metadata {
         annotations = {
           "sidecar.istio.io/inject" = false
-          "prometheus.io/port"      = "9102"
+          "prometheus.io/port"      = 8877
           "prometheus.io/scrape"    = true
+          "prometheus.io/path"      = "/metrics"
         }
 
         labels = {
-          terrafrom = "true"
+          terraform = "true",
           app       = var.name
         }
       }

--- a/daemonset.tf
+++ b/daemonset.tf
@@ -34,58 +34,6 @@ resource "kubernetes_daemonset" "this" {
         automount_service_account_token = true
         restart_policy                  = "Always"
 
-        volume {
-          name = "stats-exporter-mapping-config"
-
-          config_map {
-            name = "${var.name}-config"
-
-            items {
-              key  = "exporterConfiguration"
-              path = "mapping-config.yaml"
-            }
-          }
-        }
-
-        container {
-          name              = "${var.name}-statsd-sink"
-          image             = "${var.exporter_image}:${var.exporter_image_tag}"
-          image_pull_policy = var.image_pull_policy
-
-          args = [
-            "-statsd.listen-address=:8125",
-            "-statsd.mapping-config=/statsd-exporter/mapping-config.yaml",
-          ]
-
-          resources {
-            requests {
-              memory = var.resources_statsd_requests_memory
-              cpu    = var.resources_statsd_requests_cpu
-            }
-
-            limits {
-              memory = var.resources_statsd_limits_memory
-              cpu    = var.resources_statsd_limits_cpu
-            }
-          }
-
-          port {
-            container_port = 9102
-            name           = "metrics"
-            protocol       = "TCP"
-          }
-          port {
-            container_port = 8125
-            name           = "listener"
-            protocol       = "TCP"
-          }
-
-          volume_mount {
-            mount_path = "/statsd-exporter/"
-            name       = "stats-exporter-mapping-config"
-            read_only  = true
-          }
-        }
         container {
           name                     = var.name
           image                    = "${var.ambassador_image}:${var.ambassador_image_tag}"

--- a/deployment.tf
+++ b/deployment.tf
@@ -38,58 +38,6 @@ resource "kubernetes_deployment" "this" {
         automount_service_account_token = true
         restart_policy                  = "Always"
 
-        volume {
-          name = "stats-exporter-mapping-config"
-
-          config_map {
-            name = "${var.name}-config"
-
-            items {
-              key  = "exporterConfiguration"
-              path = "mapping-config.yaml"
-            }
-          }
-        }
-
-        container {
-          name              = "${var.name}-statsd-sink"
-          image             = "${var.exporter_image}:${var.exporter_image_tag}"
-          image_pull_policy = var.image_pull_policy
-
-          args = [
-            "-statsd.listen-address=:8125",
-            "-statsd.mapping-config=/statsd-exporter/mapping-config.yaml",
-          ]
-
-          resources {
-            requests {
-              memory = var.resources_statsd_requests_memory
-              cpu    = var.resources_statsd_requests_cpu
-            }
-
-            limits {
-              memory = var.resources_statsd_limits_memory
-              cpu    = var.resources_statsd_limits_cpu
-            }
-          }
-
-          port {
-            container_port = 9102
-            name           = "metrics"
-            protocol       = "TCP"
-          }
-          port {
-            container_port = 8125
-            name           = "listener"
-            protocol       = "TCP"
-          }
-
-          volume_mount {
-            mount_path = "/statsd-exporter/"
-            name       = "stats-exporter-mapping-config"
-            read_only  = true
-          }
-        }
         container {
           name                     = var.name
           image                    = "${var.ambassador_image}:${var.ambassador_image_tag}"
@@ -116,21 +64,6 @@ resource "kubernetes_deployment" "this" {
           env {
             name  = "AMBASSADOR_DEBUG"
             value = var.ambassador_debug
-          }
-
-          env {
-            name  = "STATSD_ENABLED"
-            value = true
-          }
-
-          env {
-            name  = "STATSD_HOST"
-            value = "localhost"
-          }
-
-          env {
-            name  = "STATSD_PORT"
-            value = 8125
           }
 
           env {

--- a/deployment.tf
+++ b/deployment.tf
@@ -22,12 +22,13 @@ resource "kubernetes_deployment" "this" {
       metadata {
         annotations = {
           "sidecar.istio.io/inject" = false
-          "prometheus.io/port"      = "9102"
+          "prometheus.io/port"      = 8877
           "prometheus.io/scrape"    = true
+          "prometheus.io/path"      = "/metrics"
         }
 
         labels = {
-          terrafrom = "true",
+          terraform = "true",
           app       = var.name
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -76,26 +76,6 @@ variable "resources_limits_memory" {
   default     = "1Gi"
 }
 
-variable "resources_statsd_requests_cpu" {
-  description = "CPU requests for statsd sidecar container"
-  default     = "50m"
-}
-
-variable "resources_statsd_requests_memory" {
-  description = "memory requests for statsd sidecar container"
-  default     = "100Mi"
-}
-
-variable "resources_statsd_limits_cpu" {
-  description = "CPU limit for statsd sidecar container"
-  default     = "50m"
-}
-
-variable "resources_statsd_limits_memory" {
-  description = "memory limit for statsd sidecar container"
-  default     = "100Mi"
-}
-
 variable "rbac_create" {
   default     = true
   description = "If true, create and use RBAC resources"
@@ -201,16 +181,6 @@ variable "admin_service_type" {
 variable "exporter_configuration" {
   description = "	Prometheus exporter configuration in YALM format"
   default     = ""
-}
-
-variable "exporter_image" {
-  description = "	Prometheus exporter image"
-  default     = "prom/statsd-exporter"
-}
-
-variable "exporter_image_tag" {
-  description = "	Prometheus exporter image tag"
-  default     = "v0.6.0"
 }
 
 variable "timing_restart" {


### PR DESCRIPTION
Now that we're using Ambassador v1.6.0, the statsd exporter no longer works, and ambassador has a prometheus metrics endpoint by default.

This PR Removes the statsd exporter, and adds prometheus scrape configurations so that prometheus will automatically pick up our envoy metrics.

As a side note, the metrics are now waaaaaaaay nicer:
Before: `envoy_cluster_cluster_content_search_service_content_upstream_rq_200`
After: `envoy_cluster_upstream_rq{envoy_cluster_name="content_search_service", envoy_response_code="200"}`

This PR also `terrafrom` -> `terraform`