### PR TITLE
Adding Rules to Ambassador's ClusterRole

### DIFF
--- a/rbac.tf
+++ b/rbac.tf
@@ -36,8 +36,8 @@ resource "kubernetes_cluster_role" "this" {
     verbs      = ["update"]
   }
   rule {
-    api_groups = ["extensions"]
-    resources  = ["ingresses"]
+    api_groups = ["extensions", "networking.k8s.io"]
+    resources  = ["ingressclasses", "ingresses"]
     verbs      = ["get", "list", "watch"]
   }
   rule {
@@ -49,11 +49,6 @@ resource "kubernetes_cluster_role" "this" {
     api_groups = [""]
     resources  = ["configmaps"]
     verbs      = ["create", "update", "patch", "get", "list", "watch"]
-  }
-  rule {
-    api_groups = ["extensions", "networking.k8s.io"]
-    resources  = ["ingressclasses", "ingresses"]
-    verbs      = ["get", "list", "watch"]
   }
 }
 

--- a/rbac.tf
+++ b/rbac.tf
@@ -50,6 +50,11 @@ resource "kubernetes_cluster_role" "this" {
     resources  = ["configmaps"]
     verbs      = ["create", "update", "patch", "get", "list", "watch"]
   }
+  rule {
+    api_groups = ["extensions", "networking.k8s.io"]
+    resources  = ["ingressclasses", "ingresses"]
+    verbs      = ["get", "list", "watch"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "this" {


### PR DESCRIPTION
We are upgrading EKS to 1.20 & ambassador requires more/different ingress permissions.

Unsure of whether to replace the other ingress rule or add it as I have done in the first commit of this PR.

Testing the upgrade process in DS Stage cluster is where I found this issue. I resolved it by manually adding the following to the ClusterRole yaml.

```
- apiGroups:
  - extensions
  - networking.k8s.io
  resources:
  - ingresses
  - ingressclasses
  verbs:
  - get
  - list
  - watch
```